### PR TITLE
Fix get_json_object and json_tuple example

### DIFF
--- a/code/Structured_APIs-Chapter_6_Working_with_Different_Types_of_Data.py
+++ b/code/Structured_APIs-Chapter_6_Working_with_Different_Types_of_Data.py
@@ -331,8 +331,8 @@ jsonDF = spark.range(1).selectExpr("""
 from pyspark.sql.functions import get_json_object, json_tuple
 
 jsonDF.select(
-    get_json_object(col("jsonString"), "$.myJSONKey.myJSONValue[1]") as "column",
-    json_tuple(col("jsonString"), "myJSONKey")).show(2)
+    get_json_object(jsonDF.jsonString, "$.myJSONKey.myJSONValue[1]").alias("column"),
+    json_tuple(jsonDF.jsonString, "myJSONKey")).show(2)
 
 
 # COMMAND ----------


### PR DESCRIPTION
'...as "column"' not correct usage, plus col("jsonString") was causing "'DataFrame' object not callable" errors.